### PR TITLE
🏗️ Build spider: Wichita Independent Neighborhoods

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ scrapy-sentry-errors = "1.0.0"
 city-scrapers-core = {ref = "main", git = "https://github.com/City-Bureau/city-scrapers-core.git", extras = ["azure"]}
 scrapy-wayback-middleware = "*"
 python-dateutil = "*"
+icalendar = "*"
 
 [dev-packages]
 freezegun = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5a008f41025a10bfa7f5526a8e9090d3b02bad38ba77d5494e15eb629bf5f21a"
+            "sha256": "4d680f16263b1ce1500c663b32e6abc4c576a700375b355cb9469e492028e76b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,18 +33,18 @@
         },
         "azure-core": {
             "hashes": [
-                "sha256:3dae7962aad109610e68c9a7abb31d79720e1d982ddf61363038d175a5025e89",
-                "sha256:6f3a7883ef184722f6bd997262eddaf80cfe7e5b3e0caaaf8db1695695893d35"
+                "sha256:26273a254131f84269e8ea4464f3560c731f29c0c1f69ac99010845f239c1a8f",
+                "sha256:7c5ee397e48f281ec4dd773d67a0a47a0962ed6fa833036057f9ea067f688e74"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.30.0"
+            "version": "==1.30.1"
         },
         "azure-storage-blob": {
             "hashes": [
-                "sha256:26c0a4320a34a3c2a1b74528ba6812ebcb632a04cd67b1c7377232c4b01a5897",
-                "sha256:7bbc2c9c16678f7a420367fef6b172ba8730a7e66df7f4d7a55d5b3c8216615b"
+                "sha256:13e16ba42fc54ac2c7e8f976062173a5c82b9ec0594728e134aac372965a11b0",
+                "sha256:c5530dc51c21c9564e4eb706cd499befca8819b10dd89716d3fc90d747556243"
             ],
-            "version": "==12.19.0"
+            "version": "==12.19.1"
         },
         "certifi": {
             "hashes": [
@@ -285,6 +285,15 @@
             ],
             "version": "==21.0.0"
         },
+        "icalendar": {
+            "hashes": [
+                "sha256:7a298bb864526589d0de81f4b736eeb6ff9e539fefb405f7977aa5c1e201ca00",
+                "sha256:81864971ac43a1b7d0a555dc1b667836ce59fc719a7f845a96f2f03205fb83b9"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==5.0.11"
+        },
         "idna": {
             "hashes": [
                 "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
@@ -433,11 +442,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.2"
+            "version": "==24.0"
         },
         "parsel": {
             "hashes": [
@@ -488,20 +497,20 @@
         },
         "pyopenssl": {
             "hashes": [
-                "sha256:6aa33039a93fffa4563e655b61d11364d01264be8ccb49906101e02a334530bf",
-                "sha256:ba07553fb6fd6a7a2259adb9b84e12302a9a8a75c44046e8bb5d3e5ee887e3c3"
+                "sha256:17ed5be5936449c5418d1cd269a1a9e9081bc54c17aed272b45856a3d3dc86ad",
+                "sha256:cabed4bfaa5df9f1a16c0ef64a0cb65318b5cd077a7eda7d6970131ca2f41a6f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==24.0.0"
+            "version": "==24.1.0"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.8.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0.post0"
         },
         "pytz": {
             "hashes": [
@@ -670,15 +679,15 @@
                 "sha256:fd2b8500d64b909289e3541c201b4d672c0e7b458fc20e77bb37f0d71d93a75a"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.1' and python_version < '4.0'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
             "version": "==0.3.3"
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:becda09660df63e55f307570e9817c664392655a7328bbc414b507e9cb874c67",
-                "sha256:f143f3fb4bb57c90abef6e2ad06b5f6f02b2ca13e4060ec5c0549c7a9ccce3fa"
+                "sha256:4f2d6c43c07925d8cd10dfbd0970ea7cb784f70e79523cca9dbcd72df38e5a46",
+                "sha256:be4f8f4b29a80b6a3b71f0f31487beb9e296391da20af8504498a328befed53f"
             ],
-            "version": "==1.40.6"
+            "version": "==1.41.0"
         },
         "service-identity": {
             "hashes": [
@@ -701,7 +710,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tldextract": {
@@ -714,11 +723,11 @@
         },
         "twisted": {
             "hashes": [
-                "sha256:4ae8bce12999a35f7fe6443e7f1893e6fe09588c8d2bed9c35cdce8ff2d5b444",
-                "sha256:987847a0790a2c597197613686e2784fd54167df3a55d0fb17c8412305d76ce5"
+                "sha256:039f2e6a49ab5108abd94de187fa92377abe5985c7a72d68d0ad266ba19eae63",
+                "sha256:6b38b6ece7296b5e122c9eb17da2eeab3d98a198f50ca9efd00fb03e5b4fd4ae"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==23.10.0"
+            "version": "==24.3.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -886,11 +895,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5",
-                "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"
+                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.2"
+            "version": "==24.0"
         },
         "pathspec": {
             "hashes": [
@@ -934,28 +943,28 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd",
-                "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"
+                "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7",
+                "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.0.2"
+            "version": "==8.1.1"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
-                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.8.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0.post0"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tomli": {

--- a/city_scrapers/spiders/wicks_win.py
+++ b/city_scrapers/spiders/wicks_win.py
@@ -1,0 +1,68 @@
+from city_scrapers_core.constants import NOT_CLASSIFIED
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+from icalendar import Calendar
+
+
+class WicksWinSpider(CityScrapersSpider):
+    name = "wicks_win"
+    agency = "Wichita Independent Neighborhoods"
+    timezone = "America/Chicago"
+    start_urls = ["https://winwichita.org/events/list/?ical=1"]
+    custom_settings = {
+        "DEFAULT_REQUEST_HEADERS": {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",  # noqa
+            "Accept": "text/calendar,*/*;q=0.9",
+        }
+    }
+
+    def parse(self, response):
+        """
+        Parses the iCalendar feed and yields a Meeting object for each event.
+        """
+        cal = Calendar.from_ical(response.body)
+        for component in cal.walk():
+            if component.name == "VEVENT":
+                meeting = Meeting(
+                    title=component.get("summary"),
+                    description=component.get("description"),
+                    classification=NOT_CLASSIFIED,
+                    start=self._parse_start(component),
+                    end=self._parse_end(component),
+                    all_day=False,
+                    time_notes="",
+                    location=self._parse_location(component),
+                    links=[],
+                    source=(
+                        component.get("url") if component.get("url") else response.url
+                    ),
+                )
+                meeting["status"] = self._get_status(meeting)
+                meeting["id"] = self._get_id(meeting)
+
+                yield meeting
+
+    def _parse_start(self, component):
+        """Gets a start date from an iCalendar component and
+        converts the datetime to a Timezone naive datetime object."""
+        start_date = component.get("dtstart")
+        return start_date.dt.replace(tzinfo=None) if start_date else None
+
+    def _parse_end(self, component):
+        """Gets an end date from an iCalendar component and
+        converts the datetime to a Timezone naive datetime object."""
+        end_date = component.get("dtend")
+        return end_date.dt.replace(tzinfo=None) if end_date else None
+
+    def _parse_location(self, component):
+        """Parse or generate location."""
+        location = component.get("location")
+        if not location:
+            return {
+                "name": "TBD",
+                "address": "",
+            }
+        return {
+            "name": "",
+            "address": str(location),
+        }

--- a/tests/files/wicks_win.ics
+++ b/tests/files/wicks_win.ics
@@ -1,0 +1,230 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Wichita Independent Neighborhoods, Inc. - ECPv6.3.3.1//NONSGML v1.0//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Wichita Independent Neighborhoods, Inc.
+X-ORIGINAL-URL:https://winwichita.org
+X-WR-CALDESC:Events for Wichita Independent Neighborhoods, Inc.
+REFRESH-INTERVAL;VALUE=DURATION:PT1H
+X-Robots-Tag:noindex
+X-PUBLISHED-TTL:PT1H
+BEGIN:VTIMEZONE
+TZID:America/Chicago
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0600
+TZOFFSETTO:-0500
+TZNAME:CDT
+DTSTART:20240310T080000
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0600
+TZNAME:CST
+DTSTART:20241103T070000
+END:STANDARD
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0600
+TZOFFSETTO:-0500
+TZNAME:CDT
+DTSTART:20250309T080000
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0600
+TZNAME:CST
+DTSTART:20251102T070000
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240308T180000
+DTEND;TZID=America/Chicago:20240308T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033729Z
+LAST-MODIFIED:20240112T033729Z
+UID:728-1709920800-1709926200@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-23/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240411T180000
+DTEND;TZID=America/Chicago:20240411T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033730Z
+LAST-MODIFIED:20240112T033730Z
+UID:729-1712858400-1712863800@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-24/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240427T100000
+DTEND;TZID=America/Chicago:20240427T120000
+DTSTAMP:20240308T121004
+CREATED:20240209T003405Z
+LAST-MODIFIED:20240209T003441Z
+UID:750-1714212000-1714219200@winwichita.org
+SUMMARY:Quarterly Community Gathering
+DESCRIPTION:WIN Members and prospective members meet for refreshments and discussion of neighborhood concerns and goals.
+URL:https://winwichita.org/event/community-gathering/
+LOCATION:Urban League of Wichita\, 2418 E 9th Street\, Wichita\, KS\, 67214\, United States
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240509T180000
+DTEND;TZID=America/Chicago:20240509T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033732Z
+LAST-MODIFIED:20240112T033732Z
+UID:730-1715277600-1715283000@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-25/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240613T180000
+DTEND;TZID=America/Chicago:20240613T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033735Z
+LAST-MODIFIED:20240112T033735Z
+UID:731-1718301600-1718307000@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-26/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240711T180000
+DTEND;TZID=America/Chicago:20240711T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033735Z
+LAST-MODIFIED:20240112T033735Z
+UID:732-1720720800-1720726200@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-27/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240727T100000
+DTEND;TZID=America/Chicago:20240727T120000
+DTSTAMP:20240308T121004
+CREATED:20240209T004022Z
+LAST-MODIFIED:20240209T004659Z
+UID:756-1722074400-1722081600@winwichita.org
+SUMMARY:Quarterly Meeting
+DESCRIPTION:WIN Members will mobilize to support a cleanup.
+URL:https://winwichita.org/event/quarterly-meeting/
+LOCATION:Urban League of Wichita\, 2418 E 9th Street\, Wichita\, KS\, 67214\, United States
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240808T180000
+DTEND;TZID=America/Chicago:20240808T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033735Z
+LAST-MODIFIED:20240112T033735Z
+UID:733-1723140000-1723145400@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-28/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20240912T180000
+DTEND;TZID=America/Chicago:20240912T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033735Z
+LAST-MODIFIED:20240112T033735Z
+UID:734-1726164000-1726169400@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-29/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20241005T100000
+DTEND;TZID=America/Chicago:20241005T120000
+DTSTAMP:20240308T121004
+CREATED:20240209T004448Z
+LAST-MODIFIED:20240209T004448Z
+UID:758-1728122400-1728129600@winwichita.org
+SUMMARY:Quarterly Meeting
+DESCRIPTION:WIN Members and prospective members meet for refreshments and discussion of neighborhood concerns and goals.
+URL:https://winwichita.org/event/quarterly-meeting-2/
+LOCATION:Urban League of Wichita\, 2418 E 9th Street\, Wichita\, KS\, 67214\, United States
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20241010T180000
+DTEND;TZID=America/Chicago:20241010T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033735Z
+LAST-MODIFIED:20240112T033735Z
+UID:735-1728583200-1728588600@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-30/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20241114T180000
+DTEND;TZID=America/Chicago:20241114T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033750Z
+LAST-MODIFIED:20240112T033750Z
+UID:736-1731607200-1731612600@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-31/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20241212T180000
+DTEND;TZID=America/Chicago:20241212T193000
+DTSTAMP:20240308T121004
+CREATED:20240112T033750Z
+LAST-MODIFIED:20240112T161005Z
+UID:737-1734026400-1734031800@winwichita.org
+SUMMARY:Executive Board Meeting
+DESCRIPTION:This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January.
+URL:https://winwichita.org/event/executive-board-meeting-32/
+LOCATION:General Membership Meeting Locale\, 2418 E 9th St N\, Wichita\, KS\, 67214\, United States
+CATEGORIES:Board
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20250127T180000
+DTEND;TZID=America/Chicago:20250127T210000
+DTSTAMP:20240308T121004
+CREATED:20240209T004917Z
+LAST-MODIFIED:20240209T005055Z
+UID:762-1738000800-1738011600@winwichita.org
+SUMMARY:WIN Annual Meeting
+DESCRIPTION:Details Pending.
+URL:https://winwichita.org/event/win-annual-meeting-2/
+ORGANIZER;CN="Wichita Independent Neighborhoods%2C Inc":MAILTO:membership@winwichita.org
+END:VEVENT
+END:VCALENDAR

--- a/tests/test_wicks_win.py
+++ b/tests/test_wicks_win.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import NOT_CLASSIFIED, PASSED
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.wicks_win import WicksWinSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "wicks_win.ics"),
+    url="https://winwichita.org/events/list/?ical=1",
+)
+spider = WicksWinSpider()
+
+freezer = freeze_time(datetime(2024, 3, 9, 8, 22))
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+parsed_item = parsed_items[0]
+freezer.stop()
+
+
+def test_title():
+    assert parsed_item["title"] == "Executive Board Meeting"
+
+
+def test_description():
+    assert (
+        parsed_item["description"]
+        == "This is the closed monthly meeting of WIN’s Executive Board. We meet the second Thursday of every month beginning in January."  # noqa
+    )
+
+
+def test_start():
+    assert parsed_item["start"] == datetime(2024, 3, 8, 18, 0)
+
+
+def test_end():
+    assert parsed_item["end"] == datetime(2024, 3, 8, 19, 30)
+
+
+def test_time_notes():
+    assert parsed_item["time_notes"] == ""
+
+
+def test_id():
+    assert parsed_item["id"] == "wicks_win/202403081800/x/executive_board_meeting"
+
+
+def test_status():
+    assert parsed_item["status"] == PASSED
+
+
+def test_location():
+    assert parsed_item["location"] == {
+        "name": "",
+        "address": "General Membership Meeting Locale, 2418 E 9th St N, Wichita, KS, 67214, United States",  # noqa
+    }
+
+
+def test_source():
+    assert (
+        parsed_item["source"]
+        == "https://winwichita.org/event/executive-board-meeting-23/"
+    )
+
+
+def test_links():
+    assert parsed_item["links"] == []
+
+
+def test_classification():
+    assert parsed_item["classification"] == NOT_CLASSIFIED
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False


### PR DESCRIPTION
## What's this PR do?
Adds a spider to scrape public meetings from the iCalendar link promoted on the website of Wichita Independent Neighborhoods. The new spider is called `wicks_win`.

## Why are we doing this?
Requested by our site partners.

## Steps to manually test

1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl wicks_win -O test_output.csv
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `test_output.csv` to ensure the data looks valid. Target website is [here]().

## Are there any smells or added technical debt to note?
- I opted to parse the agency's iCalendar feed rather than its HTML. Targeting the iCalendar feed means we get nicely structured data. As far as I could tell, the details rendered in the site's HTML are pretty much the same as the info in its iCalendar feed.
- As far as I'm aware, we don't have many spiders that parse iCalendar feeds. Here's one for [Detroit](https://github.com/City-Bureau/city-scrapers-det/blob/1491c90d64de1940ec74aeceafbb1bca0297734f/city_scrapers/spiders/det_board_of_education.py#L23). Unlike that one, I opted to parse the feed with the [icalendar](https://github.com/collective/icalendar) package to speed up dev time a bit and keep the code tidy. The package appears well maintained and may make it easier to maintain this spider in the event of changes to the [RFC 5545](https://www.ietf.org/rfc/rfc5545.txt) spec.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206605723222350