### PR TITLE
🐛 Fix: bump actions to prevent failing workflows

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -18,10 +18,10 @@ jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -29,7 +29,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         python-version: [3.9]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -29,7 +29,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pip-${{ matrix.python-version }}-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,10 +24,10 @@ jobs:
   crawl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -35,7 +35,7 @@ jobs:
         run: pip install --user pipenv
 
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: ${{ env.PYTHON_VERSION }}-${{ hashFiles('**/Pipfile.lock') }}


### PR DESCRIPTION
## What's this PR do?
Upgrades helper actions in our Github workflows to the latest versions: checkout (v4), setup-python (v5) and cache actions (v4).

## Why are we doing this?
This attempts to fix a mysterious dependency bug in our Github workflows. Although they were previously working fine, they suddenly stopped working. The first failure for the Archive job was Tue, 26 Mar 2024, but the last PR was Wed Mar 20. The Archive action ran several times after Mar 20 without failure.

Without doing an extensive deep dive, my guess is that something changed in either the Github-hosted task runner or one of our sub dependencies. Initially, I thought the issue might relate to these warnings about the Node env being used in the Github taskrunner:

![image](https://github.com/City-Bureau/city-scrapers-wichita/assets/37225902/1bf0df98-32ca-4eee-8170-85e362a7dc94)

Our versions of checkout, setup-python  and cache actions in each of our workflows is quite dated at this point. Bumping the versions appears to have fixed things but it's hard to be certain because my new PR caused the Github task runner cache to refresh. Based on my experience with other city-scraper repos that have suffered dependency issues, simply clearing the Github taskrunner cache can sometimes (temporarily) fix the issue. In retrospect, I should have cleared the cache first and re-ran the jobs to see if they still failed.

## Steps to manually test
N/A

## Are there any smells or added technical debt to note?
See the above notes. It's a bit unclear if this fixes the underlying issue. We'll keep an eye on it.