### PR TITLE
Build spider: Sedgwick County Commissioners

### DIFF
--- a/city_scrapers/spiders/wicks_bocc.py
+++ b/city_scrapers/spiders/wicks_bocc.py
@@ -1,0 +1,129 @@
+from urllib.parse import urljoin
+
+from city_scrapers_core.constants import COMMISSION
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+from dateutil.parser import parse
+
+
+class WicksBoccSpider(CityScrapersSpider):
+    name = "wicks_bocc"
+    agency = "Board of Sedgwick County Commissioners"
+    timezone = "America/Chicago"
+    # original https://www.sedgwickcounty.org/commissioners/commission-meetings/
+    start_urls = ["https://sedgwick.granicus.com/ViewPublisher.php?view_id=34"]
+    location = {
+        "name": "Ruffin Auditorium",
+        "address": "100 N. Broadway, Lower Level, Wichita, KS 67202",
+    }
+
+    def parse(self, response):
+        """Parse meeting items from agency website iframe."""
+
+        # get upcoming events
+        for item in response.css("table")[0].css("tbody tr"):
+            meeting = Meeting(
+                title=item.css("td")[0].css("::text").get(),
+                description="",
+                classification=COMMISSION,
+                start=self._parse_start(item),
+                end="",
+                all_day=False,
+                time_notes=self._parse_time_notes(item),
+                location=self.location,
+                links=self._parse_links(response, item),
+                source=response.url,
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+        # get archived events in current year
+        for item in response.css(".TabbedPanelsContent")[0].css("table tbody tr"):
+            # pdb.set_trace()
+            # skip if row does not have enough data cells to avoid IndexErrors
+            if len(item.css("td")) < 2:
+                continue
+
+            meeting = Meeting(
+                title=self._parse_title(item),
+                description="",
+                classification=COMMISSION,
+                start=self._parse_start(item),
+                end="",
+                all_day=False,
+                time_notes="",
+                location=self.location,
+                links=self._parse_links(response, item),
+                source=response.url,
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+    def _parse_start(self, item):
+        """Parse start datetime as a naive datetime object."""
+
+        # Attempt to get date
+        try:
+            date_cell = item.css("td")[1]
+            raw_date = date_cell.css("::text").get()
+            clean_date = raw_date.strip().replace("\xa0", " ")
+            parsed_date = parse(clean_date)
+        except IndexError:
+            # Handle the case where the file doesn't exist
+            parsed_date = None
+
+        # attempt to get time
+        # agenda_url = item.css('td')[2].css('a::attr(href)').get()
+        # Check if the agenda URL is found
+        # if agenda_url:
+        #     full_url = urljoin(response.url, agenda_url)
+        #     # Follow the agenda URL
+        #     response2 = scrapy.Request(full_url, callback=self._parse_agenda)
+        #     pdb.set_trace()
+        # else:
+        #     self.logger.info('Second URL not found on first page')
+
+        return parsed_date
+
+    # def _parse_agenda(self, response):
+    #     # pdb.set_trace()
+    #     # Extract data from the second page
+    #     data = {
+    #         'title': response.css('h1::text').get(),
+    #         'content': response.css('div.content::text').get()
+    #     }
+    #     yield data
+
+    def _parse_time_notes(self, item):
+        """
+        Parse any additional notes on the timing of the meeting.
+        If Agenda link is given, meeting start time may be found in there.
+        Eventually we could scrape the link
+        but for now we can just tell user to check link themselves.
+        """
+        agenda_url = item.css("td")[2].css("a::attr(href)").get()
+        return "Check Agenda for start time." if agenda_url else ""
+
+    def _parse_links(self, response, item):
+        """Parse or generate links."""
+        output = []
+
+        title = item.css("a::text").get()
+
+        # find URL based on content of link title
+        if title and "Agenda" in title:
+            link_url = item.css("a::attr(href)").get()
+            full_url = urljoin(response.url, link_url)
+            output.append({"title": title, "href": full_url})
+        elif title and "Video" in title:
+            link_url = item.css("a::attr(onclick)").get().split("'")[1]
+            full_url = urljoin(response.url, link_url)
+            output.append({"title": "Video", "href": full_url})
+
+        return output

--- a/city_scrapers/spiders/wicks_bocc.py
+++ b/city_scrapers/spiders/wicks_bocc.py
@@ -77,14 +77,10 @@ class WicksBoccSpider(CityScrapersSpider):
         Fetch from correct table cell and clean up.
         """
 
-        # attempt to get date
-        try:
-            date_cell = item.css("td")[1]
-            raw_date = date_cell.css("::text").get()
-            clean_date = raw_date.strip().replace("\xa0", " ")
-            parsed_date = parse(clean_date)
-        except IndexError:
-            parsed_date = None
+        date_cell = item.css("td")[1]
+        raw_date = date_cell.css("::text").get()
+        clean_date = raw_date.strip().replace("\xa0", " ")
+        parsed_date = parse(clean_date)
 
         return parsed_date
 

--- a/city_scrapers/spiders/wicks_bocc.py
+++ b/city_scrapers/spiders/wicks_bocc.py
@@ -11,8 +11,8 @@ class WicksBoccSpider(CityScrapersSpider):
     agency = "Board of Sedgwick County Commissioners"
     timezone = "America/Chicago"
     # original https://www.sedgwickcounty.org/commissioners/commission-meetings/
-    # Original page embeds iframe with the following URL.
-    # We scrape the embedded URL instead.
+    # original page embeds iframe with the following URL
+    # we scrape the embedded URL instead
     start_urls = ["https://sedgwick.granicus.com/ViewPublisher.php?view_id=34"]
     location = {
         "name": "Ruffin Auditorium",
@@ -42,9 +42,8 @@ class WicksBoccSpider(CityScrapersSpider):
 
             yield meeting
 
-        # get archived events in current year
+        # get archived events in current year. ignore all other years
         for item in response.css(".TabbedPanelsContent")[0].css("table tbody tr"):
-            # pdb.set_trace()
             # skip if row does not have enough data cells to avoid IndexErrors
             if len(item.css("td")) < 2:
                 continue
@@ -73,7 +72,7 @@ class WicksBoccSpider(CityScrapersSpider):
         Fetch from correct table cell and clean up.
         """
 
-        # Attempt to get date
+        # attempt to get date
         try:
             date_cell = item.css("td")[1]
             raw_date = date_cell.css("::text").get()

--- a/city_scrapers/spiders/wicks_sedgwick_bocc.py
+++ b/city_scrapers/spiders/wicks_sedgwick_bocc.py
@@ -4,10 +4,9 @@ from city_scrapers_core.constants import COMMISSION
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
 from dateutil.parser import parse
-import pdb
 
 
-class WicksBoccSpider(CityScrapersSpider):
+class WicksSedgwickBoccSpider(CityScrapersSpider):
     name = "wicks_bocc"
     agency = "Board of Sedgwick County Commissioners"
     timezone = "America/Chicago"

--- a/city_scrapers/spiders/wicks_sedgwick_bocc.py
+++ b/city_scrapers/spiders/wicks_sedgwick_bocc.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 
 
 class WicksSedgwickBoccSpider(CityScrapersSpider):
-    name = "wicks_bocc"
+    name = "wicks_sedgwick_bocc"
     agency = "Board of Sedgwick County Commissioners"
     timezone = "America/Chicago"
     custom_settings = {

--- a/tests/test_wicks_bocc.py
+++ b/tests/test_wicks_bocc.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import COMMISSION, TENTATIVE
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.wicks_bocc import WicksBoccSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "wicks_bocc.html"),
+    url="https://sedgwick.granicus.com/ViewPublisher.php?view_id=34",
+)
+spider = WicksBoccSpider()
+
+freezer = freeze_time("2024-04-08")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+
+freezer.stop()
+
+
+def test_count():
+    assert len(parsed_items) == 51
+
+
+def test_title():
+    assert parsed_items[0]["title"] == "Governing Body of Fire District 1"
+
+
+def test_description():
+    assert parsed_items[0]["description"] == ""
+
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2024, 4, 10, 0, 0)
+    assert parsed_items[3]["start"] == datetime(2024, 4, 4, 0, 0)
+
+
+def test_end():
+    assert parsed_items[0]["end"] == ""
+
+
+def test_time_notes():
+    assert parsed_items[0]["time_notes"] == "Check Agenda for start time."
+    assert parsed_items[3]["time_notes"] == ""
+
+
+def test_id():
+    assert (
+        parsed_items[0]["id"]
+        == "wicks_bocc/202404100000/x/governing_body_of_fire_district_1"
+    )
+
+
+def test_status():
+    assert parsed_items[0]["status"] == TENTATIVE
+
+
+def test_location():
+    assert parsed_items[0]["location"] == {
+        "name": "Ruffin Auditorium",
+        "address": "100 N. Broadway, Lower Level, Wichita, KS 67202",
+    }
+
+
+def test_source():
+    assert (
+        parsed_items[0]["source"]
+        == "https://sedgwick.granicus.com/ViewPublisher.php?view_id=34"
+    )
+
+
+def test_links():
+    assert parsed_items[0]["links"] == [
+        {
+            "title": "Agenda",
+            "href": "https://sedgwick.granicus.com/AgendaViewer.php?view_id=34&event_id=1912",  # noqa
+        }
+    ]
+    assert parsed_items[3]["links"] == [
+        {
+            "title": "Video",
+            "href": "https://sedgwick.granicus.com/MediaPlayer.php?view_id=34&clip_id=5350",  # noqa
+        }
+    ]
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == COMMISSION
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False

--- a/tests/test_wicks_bocc.py
+++ b/tests/test_wicks_bocc.py
@@ -40,11 +40,14 @@ def test_start():
 
 
 def test_end():
-    assert parsed_items[0]["end"] == ""
+    assert parsed_items[0]["end"] == None
+    assert parsed_items[3]["end"] == None
 
 
 def test_time_notes():
-    assert parsed_items[0]["time_notes"] == "Check Agenda for start time."
+    # only upcoming events get time notes
+    assert parsed_items[0]["time_notes"] == "Refer to agenda for start time or contact agency for details."
+    # archived events do not get time notes
     assert parsed_items[3]["time_notes"] == ""
 
 
@@ -85,6 +88,21 @@ def test_links():
             "title": "Video",
             "href": "https://sedgwick.granicus.com/MediaPlayer.php?view_id=34&clip_id=5350",  # noqa
         }
+    ]
+    assert parsed_items[30]["links"] == [
+        {
+            "title": "Agenda",
+            "href": "https://sedgwick.granicus.com/AgendaViewer.php?view_id=34&clip_id=5322",  # noqa
+        },
+        {
+            'title': 'Minutes',
+            'href': 'https://sedgwick.granicus.com/MinutesViewer.php?view_id=34&clip_id=5322&doc_id=dac37c29-e850-11ee-98bb-0050569183fa',  # noqa
+        },
+        {
+            'title': 'Video',
+            'href': 'https://sedgwick.granicus.com/MediaPlayer.php?view_id=34&clip_id=5322',  # noqa
+        },
+
     ]
 
 

--- a/tests/test_wicks_sedgwick_bocc.py
+++ b/tests/test_wicks_sedgwick_bocc.py
@@ -57,7 +57,7 @@ def test_time_notes():
 def test_id():
     assert (
         parsed_items[0]["id"]
-        == "wicks_bocc/202404100000/x/governing_body_of_fire_district_1"
+        == "wicks_sedgwick_bocc/202404100000/x/governing_body_of_fire_district_1"
     )
 
 

--- a/tests/test_wicks_sedgwick_bocc.py
+++ b/tests/test_wicks_sedgwick_bocc.py
@@ -6,13 +6,13 @@ from city_scrapers_core.constants import COMMISSION, TENTATIVE
 from city_scrapers_core.utils import file_response
 from freezegun import freeze_time
 
-from city_scrapers.spiders.wicks_bocc import WicksBoccSpider
+from city_scrapers.spiders.wicks_sedgwick_bocc import WicksSedgwickBoccSpider
 
 test_response = file_response(
-    join(dirname(__file__), "files", "wicks_bocc.html"),
+    join(dirname(__file__), "files", "wicks_sedgwick_bocc.html"),
     url="https://sedgwick.granicus.com/ViewPublisher.php?view_id=34",
 )
-spider = WicksBoccSpider()
+spider = WicksSedgwickBoccSpider()
 
 freezer = freeze_time("2024-04-08")
 freezer.start()

--- a/tests/test_wicks_sedgwick_bocc.py
+++ b/tests/test_wicks_sedgwick_bocc.py
@@ -40,8 +40,8 @@ def test_start():
 
 
 def test_end():
-    assert parsed_items[0]["end"] == None
-    assert parsed_items[3]["end"] == None
+    assert parsed_items[0]["end"] is None
+    assert parsed_items[3]["end"] is None
 
 
 def test_time_notes():

--- a/tests/test_wicks_sedgwick_bocc.py
+++ b/tests/test_wicks_sedgwick_bocc.py
@@ -46,7 +46,10 @@ def test_end():
 
 def test_time_notes():
     # only upcoming events get time notes
-    assert parsed_items[0]["time_notes"] == "Refer to agenda for start time or contact agency for details."
+    assert (
+        parsed_items[0]["time_notes"]
+        == "Refer to agenda for start time or contact agency for details."
+    )
     # archived events do not get time notes
     assert parsed_items[3]["time_notes"] == ""
 
@@ -95,14 +98,13 @@ def test_links():
             "href": "https://sedgwick.granicus.com/AgendaViewer.php?view_id=34&clip_id=5322",  # noqa
         },
         {
-            'title': 'Minutes',
-            'href': 'https://sedgwick.granicus.com/MinutesViewer.php?view_id=34&clip_id=5322&doc_id=dac37c29-e850-11ee-98bb-0050569183fa',  # noqa
+            "title": "Minutes",
+            "href": "https://sedgwick.granicus.com/MinutesViewer.php?view_id=34&clip_id=5322&doc_id=dac37c29-e850-11ee-98bb-0050569183fa",  # noqa
         },
         {
-            'title': 'Video',
-            'href': 'https://sedgwick.granicus.com/MediaPlayer.php?view_id=34&clip_id=5322',  # noqa
+            "title": "Video",
+            "href": "https://sedgwick.granicus.com/MediaPlayer.php?view_id=34&clip_id=5322",  # noqa
         },
-
     ]
 
 


### PR DESCRIPTION
## What's this PR do?
This PR adds a Sedgwick County, KS scraper for County Commissioners. 

## Why are we doing this?
Scraper needed for this agency.

## Steps to manually test
1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl wicks_bocc -O test_output.csv
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `test_output.csv` to ensure the data looks valid.
6. Ensure all tests pass
```
pytest
```

## Are there any smells or added technical debt to note?
On the embedded page, there were meetings for 
- Upcoming Events
- Board of Bids and Contracts Meetings
- Board of County Commissioners Agenda Review Meetings
- Board of County Commissioners Regular & Special Meetings
- Board of County Commissioners Staff Meetings
- Miscellaneous Board of County Commissioners Meetings
- Press Conferences

The page also had meetings for the last 20 years, 2004 thru 2024. 

I assumed that we only wanted meetings from the current year, past and upcoming. This approach yielded 51 meetings in this year so far, Mar 8, 2024. This may be too many meetings being scraped. Can adjust upon request.

Also, upcoming meeting times could sometimes be found by following agenda links. Attempted to write a function for fetching those times but did not immediately succeed so I abandoned the idea and left a note for users to check agenda manually instead.