### PR TITLE
🕷️ Fix spider: Board of Sedgwick County Commissioners

### DIFF
--- a/city_scrapers/spiders/wicks_sedgwick_bocc.py
+++ b/city_scrapers/spiders/wicks_sedgwick_bocc.py
@@ -28,11 +28,14 @@ class WicksSedgwickBoccSpider(CityScrapersSpider):
 
         # get upcoming events
         for item in response.css("table")[0].css("tbody tr"):
+            start = self._parse_start(item)
+            if not start:
+                continue
             meeting = Meeting(
                 title=item.css("td")[0].css("::text").get(),
                 description="",
                 classification=COMMISSION,
-                start=self._parse_start(item),
+                start=start,
                 end=None,
                 all_day=False,
                 time_notes=self.time_notes,
@@ -51,12 +54,14 @@ class WicksSedgwickBoccSpider(CityScrapersSpider):
             # skip if row does not have enough data cells to avoid IndexErrors
             if len(item.css("td")) < 2:
                 continue
-
+            start = self._parse_start(item)
+            if not start:
+                continue
             meeting = Meeting(
                 title=item.css("td")[0].css("::text").get(),
                 description="",
                 classification=COMMISSION,
-                start=self._parse_start(item),
+                start=start,
                 end=None,
                 all_day=False,
                 time_notes="",
@@ -79,6 +84,8 @@ class WicksSedgwickBoccSpider(CityScrapersSpider):
         date_cell = item.css("td")[1]
         raw_date = date_cell.css("::text").get()
         clean_date = raw_date.strip().replace("\xa0", " ")
+        if not clean_date:
+            return None
         parsed_date = parse(clean_date)
 
         return parsed_date


### PR DESCRIPTION
## What's this PR do?

Fixes our Board of Sedgwick County Commissioners spider (aka. `wicks_sedgwick_bocc`).

## Why are we doing this?

The spider broke due to changes on the pages it's targeting. It appears that sometimes rows have empty fields for the date column. The spider now ignores any row where the date column appears to be an empty string.

## Steps to manually test

After installing the project using `pipenv`:

1. Activate the virtual environment:
```
pipenv shell
```
2. Run the spider:
```
scrapy crawl wicks_sedgwick_bocc -O test_output.csv
```
3. Monitor the stdout and ensure that the crawl proceeds without raising any errors. Pay attention to the final status report from scrapy.

4. Inspect `test_output.csv` to ensure the data looks valid. I suggest opening a few of the URLs under the source column of test_output.csv and comparing the data for the row with what you see on the page.

## Are there any smells or added technical debt to note?
